### PR TITLE
max limit

### DIFF
--- a/app/domain/common.go
+++ b/app/domain/common.go
@@ -3,4 +3,5 @@ package domain
 const (
 	DEFAULT_LIMIT  = int32(10)
 	DEFAULT_OFFSET = int32(0)
+	MAX_LIMIT      = int32(50)
 )

--- a/app/domain/errors/error.go
+++ b/app/domain/errors/error.go
@@ -12,6 +12,7 @@ const (
 	ErrNotFound            ErrorType = "Your requested Item is not found"
 	ErrConflict            ErrorType = "Your Item already exist"
 	ErrBadRequest          ErrorType = "Bad Request"
+	ErrorMaxLimit          ErrorType = "Max limit reached"
 )
 
 type ErrorResponse struct {
@@ -38,4 +39,9 @@ func NewConflictError(err error) (int, *ErrorResponse) {
 
 func NewBadRequestError(err error) (int, *ErrorResponse) {
 	return http.StatusBadRequest, NewErrorResponse(ErrBadRequest, err)
+}
+
+func NewMaxLimitError() (int, *ErrorResponse) {
+	err := fmt.Errorf("max limit reached")
+	return http.StatusBadRequest, NewErrorResponse(ErrorMaxLimit, err)
 }

--- a/app/server/controller/city_controller.go
+++ b/app/server/controller/city_controller.go
@@ -72,6 +72,10 @@ func (cc *cityController) Fetch(c echo.Context) error {
 		req.Offset = domain.DEFAULT_OFFSET
 	}
 
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
+	}
+
 	if err := c.Validate(&req); err != nil {
 		return c.JSON(errors.NewBadRequestError(err))
 	}
@@ -99,6 +103,10 @@ func (cc *cityController) FetchByPrefectureCode(c echo.Context) error {
 
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(errors.NewBadRequestError(err))
+	}
+
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
 	}
 
 	if req.Limit == 0 {

--- a/app/server/controller/city_controller_test.go
+++ b/app/server/controller/city_controller_test.go
@@ -249,6 +249,21 @@ func TestFetch(t *testing.T) {
 			},
 		},
 		{
+			name: "Max Limit Error",
+			ctx:  ctx,
+			query: query{
+				limit:  sql.NullInt32{Int32: int32(domain.MAX_LIMIT + 1), Valid: true},
+				offset: sql.NullInt32{Int32: 0, Valid: true},
+				search: sql.NullString{String: "", Valid: false},
+			},
+			buildStub: func(uc *mocks.MockCityUsecase) {
+				uc.EXPECT().Fetch(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
 			name: "Internal Server Error",
 			ctx:  ctx,
 			buildStub: func(uc *mocks.MockCityUsecase) {
@@ -396,6 +411,21 @@ func TestFetchByPrefectureCode(t *testing.T) {
 			check: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusOK, recorder.Code)
 				requireBodyMatchCities(t, recorder.Body, []*domain.City{})
+			},
+		},
+		{
+			name: "Max Limit Error",
+			ctx:  ctx,
+			code: cities[0].PrefectureCode,
+			query: query{
+				limit:  sql.NullInt32{Int32: int32(domain.MAX_LIMIT + 1), Valid: true},
+				offset: sql.NullInt32{Int32: 0, Valid: true},
+			},
+			buildStub: func(uc *mocks.MockCityUsecase) {
+				uc.EXPECT().FetchByPrefectureCode(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
 			},
 		},
 		{

--- a/app/server/controller/dish_controller.go
+++ b/app/server/controller/dish_controller.go
@@ -55,6 +55,10 @@ func (dc *dishController) GetByID(c echo.Context) error {
 		return c.JSON(errors.NewBadRequestError(err))
 	}
 
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
+	}
+
 	if req.Limit == 0 {
 		req.Limit = domain.DEFAULT_LIMIT
 	}
@@ -92,6 +96,10 @@ func (dc *dishController) GetByIdInCity(c echo.Context) error {
 		return c.JSON(errors.NewBadRequestError(err))
 	}
 
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
+	}
+
 	if req.Limit == 0 {
 		req.Limit = domain.DEFAULT_LIMIT
 	}
@@ -126,6 +134,10 @@ func (dc *dishController) Fetch(c echo.Context) error {
 
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(errors.NewBadRequestError(err))
+	}
+
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
 	}
 
 	if req.Limit == 0 {

--- a/app/server/controller/dish_controller_test.go
+++ b/app/server/controller/dish_controller_test.go
@@ -231,6 +231,25 @@ func TestGetDishByID(t *testing.T) {
 			},
 		},
 		{
+			name: "Max Limit Error",
+			req: req{
+				id:     dish.ID,
+				limit:  sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				offset: sql.NullInt32{Int32: 0, Valid: true},
+			},
+			buildStub: func(du *mocks.MockDishUsecase) {
+				arg := req{
+					id:     dish.ID,
+					limit:  sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+					offset: sql.NullInt32{Int32: 0, Valid: true},
+				}
+				du.EXPECT().GetByID(gomock.Any(), gomock.Eq(arg.id), gomock.Eq(arg.limit.Int32), gomock.Eq(arg.offset.Int32)).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, dish *domain.DishWithMenuIDs) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
 			name: "Internal Server Error",
 			req: req{
 				id:     dish.ID,
@@ -433,6 +452,27 @@ func TestGetDishByIDInCity(t *testing.T) {
 			},
 		},
 		{
+			name: "Max Limit Error",
+			req: req{
+				id:     dish.ID,
+				limit:  sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				offset: sql.NullInt32{Int32: 0, Valid: true},
+				city:   cityCode,
+			},
+			buildStub: func(du *mocks.MockDishUsecase) {
+				arg := req{
+					id:     dish.ID,
+					limit:  sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+					offset: sql.NullInt32{Int32: 0, Valid: true},
+					city:   cityCode,
+				}
+				du.EXPECT().GetByIdInCity(gomock.Any(), gomock.Eq(arg.id), gomock.Eq(arg.limit.Int32), gomock.Eq(arg.offset.Int32), gomock.Eq(arg.city)).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, dish *domain.DishWithMenuIDs) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
 			name: "Internal Server Error",
 			req: req{
 				id:     dish.ID,
@@ -486,7 +526,6 @@ func TestGetDishByIDInCity(t *testing.T) {
 
 		tc.check(t, recorder, dish)
 	}
-
 }
 
 func TestFetchDish(t *testing.T) {
@@ -591,6 +630,20 @@ func TestFetchDish(t *testing.T) {
 			},
 			buildStub: func(du *mocks.MockDishUsecase) {
 				du.EXPECT().Fetch(gomock.Any(), gomock.Eq("dish"), gomock.Eq(int32(-1)), gomock.Eq(int32(0))).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, dishes []*domain.Dish) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Max Limit Error",
+			req: req{
+				limit:  sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				offset: sql.NullInt32{Int32: 0, Valid: true},
+				search: sql.NullString{String: "dish", Valid: true},
+			},
+			buildStub: func(du *mocks.MockDishUsecase) {
+				du.EXPECT().Fetch(gomock.Any(), gomock.Eq("dish"), gomock.Eq(int32(domain.MAX_LIMIT+1)), gomock.Eq(int32(0))).Times(0)
 			},
 			check: func(t *testing.T, recorder *httptest.ResponseRecorder, dishes []*domain.Dish) {
 				require.Equal(t, http.StatusBadRequest, recorder.Code)

--- a/app/server/controller/menu_controller.go
+++ b/app/server/controller/menu_controller.go
@@ -69,6 +69,10 @@ func (mc *menuController) FetchByCity(c echo.Context) error {
 		return c.JSON(errors.NewBadRequestError(err))
 	}
 
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
+	}
+
 	if req.Limit == 0 {
 		req.Limit = domain.DEFAULT_LIMIT
 	}
@@ -127,6 +131,10 @@ func (mc *menuController) Fetch(c echo.Context) error {
 
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(errors.NewBadRequestError(err))
+	}
+
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
 	}
 
 	if req.Limit == 0 {

--- a/app/server/controller/menu_controller_test.go
+++ b/app/server/controller/menu_controller_test.go
@@ -278,6 +278,21 @@ func TestFetchMenuByCity(t *testing.T) {
 			},
 		},
 		{
+			name: "Max Limit Error",
+			req: req{
+				CityCode: cityCode,
+				Limit:    sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				Offset:   sql.NullInt32{Int32: offset, Valid: true},
+				Offered:  offered,
+			},
+			buildStub: func(uc *mocks.MockMenuUsecase) {
+				uc.EXPECT().FetchByCity(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, menus []*domain.Menu) {
+				require.Equal(t, 400, recorder.Code)
+			},
+		},
+		{
 			name: "Internal Server Error",
 			req: req{
 				CityCode: cityCode,
@@ -548,6 +563,21 @@ func TestFetchMenu(t *testing.T) {
 			check: func(t *testing.T, recorder *httptest.ResponseRecorder, menus []*domain.Menu) {
 				require.Equal(t, 200, recorder.Code)
 				requireBodyMatchMenus(t, recorder.Body, menus)
+			},
+		},
+		{
+			name: "Max Limit Error",
+			req: req{
+				Limit:   sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				Offset:  sql.NullInt32{Int32: 0, Valid: true},
+				Offered: offered,
+				IDs:     NullStrings{Valid: false},
+			},
+			buildStub: func(uc *mocks.MockMenuUsecase) {
+				uc.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, menus []*domain.Menu) {
+				require.Equal(t, 400, recorder.Code)
 			},
 		},
 		{

--- a/app/server/controller/menu_with_dishes_controller.go
+++ b/app/server/controller/menu_with_dishes_controller.go
@@ -73,6 +73,10 @@ func (mc *menuWithDishesController) FetchByCity(c echo.Context) error {
 		return c.JSON(errors.NewBadRequestError(err))
 	}
 
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
+	}
+
 	if req.Limit == 0 {
 		req.Limit = domain.DEFAULT_LIMIT
 	}
@@ -130,6 +134,10 @@ func (mc *menuWithDishesController) Fetch(c echo.Context) error {
 
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(errors.NewBadRequestError(err))
+	}
+
+	if req.Limit > domain.MAX_LIMIT {
+		return c.JSON(errors.NewMaxLimitError())
 	}
 
 	if req.Limit == 0 {

--- a/app/server/controller/menu_with_dishes_controller_test.go
+++ b/app/server/controller/menu_with_dishes_controller_test.go
@@ -254,6 +254,20 @@ func TestFetchMenuWithDishes(t *testing.T) {
 			},
 		},
 		{
+			name: "Max Limit Error",
+			req: req{
+				Limit:   sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				Offset:  sql.NullInt32{Int32: offset, Valid: true},
+				Offered: offered,
+			},
+			buildStub: func(uc *mocks.MockMenuWithDishesUsecase) {
+				uc.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, menus []*domain.MenuWithDishes) {
+				require.Equal(t, 400, recorder.Code)
+			},
+		},
+		{
 			name: "Internal Server Error",
 			req: req{
 				Limit:   sql.NullInt32{Int32: limit, Valid: true},
@@ -492,6 +506,21 @@ func TestFetchMenuWithDishesByCity(t *testing.T) {
 			check: func(t *testing.T, recorder *httptest.ResponseRecorder, menus []*domain.MenuWithDishes) {
 				require.Equal(t, 200, recorder.Code)
 				requireBodyMatchMenuWithDishesList(t, recorder.Body, menus)
+			},
+		},
+		{
+			name: "Max Limit Error",
+			req: req{
+				CityCode: cityCode,
+				Limit:    sql.NullInt32{Int32: domain.MAX_LIMIT + 1, Valid: true},
+				Offset:   sql.NullInt32{Int32: offset, Valid: true},
+				Offered:  offered,
+			},
+			buildStub: func(uc *mocks.MockMenuWithDishesUsecase) {
+				uc.EXPECT().FetchByCity(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			check: func(t *testing.T, recorder *httptest.ResponseRecorder, menus []*domain.MenuWithDishes) {
+				require.Equal(t, 400, recorder.Code)
 			},
 		},
 		{


### PR DESCRIPTION
#50 
limitの最大値の設定
validateにできるが、変更することを考慮に入れ、domain層で値を管理している。